### PR TITLE
Initial clang-tidy framework and fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# TODO discuss whether we want to enable modernize-avoid-bind, readability-implicit-bool-conversion, and readability-magic-numbers
+# TODO enable modernize-avoid-bind, readability-implicit-bool-conversion, and readability-magic-numbers
 
 FormatStyle: file
 
@@ -14,6 +14,7 @@ readability*,
 -modernize-avoid-bind,
 -modernize-use-trailing-return-type,
 -readability-implicit-bool-conversion,
+-readability-magic-numbers,
 '
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# TODO discuss whether we want to enable readability-implicit-bool-conversion and readability-magic-numbers
+# TODO discuss whether we want to enable modernize-avoid-bind, readability-implicit-bool-conversion, and readability-magic-numbers
 
 FormatStyle: file
 
@@ -11,6 +11,7 @@ llvm*,
 misc*,
 modernize*,
 readability*,
+-modernize-avoid-bind,
 -modernize-use-trailing-return-type,
 -readability-implicit-bool-conversion,
 -readability-magic-numbers,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,20 @@
+# TODO discuss whether we want to enable readability-implicit-bool-conversion and readability-magic-numbers
+
+FormatStyle: file
+
+Checks: '
+-*,
+bugprone*,
+cppcoreguidelines*
+google*,
+llvm*,
+misc*,
+modernize*,
+readability*,
+-modernize-use-trailing-return-type,
+-readability-implicit-bool-conversion,
+-readability-magic-numbers,
+'
+
+WarningsAsErrors: '*'
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ readability*,
 -modernize-avoid-bind,
 -modernize-use-trailing-return-type,
 -readability-implicit-bool-conversion,
--readability-magic-numbers,
 '
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,4 +17,3 @@ readability*,
 '
 
 WarningsAsErrors: '*'
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
         sudo snap install shfmt
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        sudo apt-get update
         sudo apt-get install -y python-catkin-tools
         sudo apt-get install -y clang-tidy-10
+        bash -c "$GITHUB_WORKSPACE/install.sh"
     - name: Init Workspace
       run: |
         mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   check:
     runs-on: ubuntu-latest
-    container: ros:melodic-robot
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
@@ -17,16 +16,6 @@ jobs:
         sudo snap install shfmt
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        sudo apt-get update
-        sudo apt-get install -y python-catkin-tools
-        sudo apt-get install -y clang-tidy-10
-        bash -c "$GITHUB_WORKSPACE/install.sh"
-    - name: Init Workspace
-      run: |
-        mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
-        cd $GITHUB_WORKSPACE/../catkin_ws/src
-        ln -s $GITHUB_WORKSPACE
-        cd ../..
     - name: Check
       run: make check
 
@@ -58,3 +47,24 @@ jobs:
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --summarize --no-status --force-color"
     - name: Test
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin run_tests --no-status --force-color && catkin_test_results"
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    container: ros:melodic-robot
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python-catkin-tools
+        sudo apt-get install -y clang-tidy-10
+        bash -c "$GITHUB_WORKSPACE/install.sh"
+    - name: Create Workspace
+      run: |
+        mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
+        cd $GITHUB_WORKSPACE/../catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+      #  cd ../..
+      #  catkin init
+    - name: Build
+      run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy-10" && catkin build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y python-catkin-tools
+        sudo apt-get install -y clang-tidy-10
         bash -c "$GITHUB_WORKSPACE/install.sh"
     - name: Init Workspace
       run: |
@@ -44,27 +45,25 @@ jobs:
         cd ..
         catkin init
     - name: Build
-      run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --summarize --no-status --force-color"
+      run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --summarize --no-status --force-color --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-10"
     - name: Test
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin run_tests --no-status --force-color && catkin_test_results"
 
-  clang-tidy:
-    runs-on: ubuntu-latest
-    container: ros:melodic-robot
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y python-catkin-tools
-        sudo apt-get install -y clang-tidy-10
-        bash -c "$GITHUB_WORKSPACE/install.sh"
-    - name: Create Workspace
-      run: |
-        mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
-        cd $GITHUB_WORKSPACE/../catkin_ws/src
-        ln -s $GITHUB_WORKSPACE
-      #  cd ../..
-      #  catkin init
-    - name: Build
-      run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy-10" && catkin build
+  # clang-tidy:
+  #   runs-on: ubuntu-latest
+  #   container: ros:melodic-robot
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Setup
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install -y python-catkin-tools
+  #       sudo apt-get install -y clang-tidy-10
+  #       bash -c "$GITHUB_WORKSPACE/install.sh"
+  #   - name: Create Workspace
+  #     run: |
+  #       mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
+  #       cd $GITHUB_WORKSPACE/../catkin_ws/src
+  #       ln -s $GITHUB_WORKSPACE
+  #   - name: Check
+  #     run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,22 +48,3 @@ jobs:
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --summarize --no-status --force-color --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-10"
     - name: Test
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin run_tests --no-status --force-color && catkin_test_results"
-
-  # clang-tidy:
-  #   runs-on: ubuntu-latest
-  #   container: ros:melodic-robot
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Setup
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install -y python-catkin-tools
-  #       sudo apt-get install -y clang-tidy-10
-  #       bash -c "$GITHUB_WORKSPACE/install.sh"
-  #   - name: Create Workspace
-  #     run: |
-  #       mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
-  #       cd $GITHUB_WORKSPACE/../catkin_ws/src
-  #       ln -s $GITHUB_WORKSPACE
-  #   - name: Check
-  #     run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y python-catkin-tools
-        sudo apt-get install -y clang-tidy-10
         bash -c "$GITHUB_WORKSPACE/install.sh"
     - name: Init Workspace
       run: |
@@ -44,7 +43,7 @@ jobs:
         ln -s $GITHUB_WORKSPACE
         cd ..
         catkin init
-    - name: Build
+    - name: Build and Check
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin build --summarize --no-status --force-color --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-10"
     - name: Test
       run: bash -c "source /opt/ros/melodic/setup.bash && source /opt/carla-ros-bridge/melodic/setup.bash && cd $GITHUB_WORKSPACE/../catkin_ws && catkin run_tests --no-status --force-color && catkin_test_results"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,14 @@ jobs:
         sudo snap install shfmt
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        sudo apt-get install -y python-catkin-tools
+        sudo apt-get install -y clang-tidy-10
+    - name: Init Workspace
+      run: |
+        mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
+        cd $GITHUB_WORKSPACE/../catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd ../..
     - name: Check
       run: make check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   check:
     runs-on: ubuntu-latest
+    container: ros:melodic-robot
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PY_FILES = $(call file_finder,-name "*.py")
 CPP_FILES = $(call file_finder,-regex '.*\.\(cpp\|hpp\|cu\|c\|h\)')
 SH_FILES = $(call file_finder,-name "*.sh")
 
-check: check_format check_sh_format pylint shellcheck clang_tidy
+check: check_format check_sh_format pylint shellcheck
 
 format:
 	$(PY_FILES) | xargs black
@@ -25,7 +25,3 @@ check_sh_format:
 
 shellcheck:
 	$(SH_FILES) | xargs shellcheck
-
-clang_tidy:
-	catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy-10"
-	catkin build

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PY_FILES = $(call file_finder,-name "*.py")
 CPP_FILES = $(call file_finder,-regex '.*\.\(cpp\|hpp\|cu\|c\|h\)')
 SH_FILES = $(call file_finder,-name "*.sh")
 
-check: check_format check_sh_format pylint shellcheck
+check: check_format check_sh_format pylint shellcheck clang_tidy
 
 format:
 	$(PY_FILES) | xargs black
@@ -25,3 +25,7 @@ check_sh_format:
 
 shellcheck:
 	$(SH_FILES) | xargs shellcheck
+
+clang_tidy:
+	catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy-10"
+	catkin build

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TELECARLA so far has been tested on
 | Ubuntu 18.04 | Melodic |
 
 1. Download [CARLA](https://github.com/carla-simulator/carla/releases/latest)
-1. Install [ROS](http://wiki.ros.org/ROS/Installation)
+1. Install [ROS](http://wiki.ros.org/ROS/Installation) and [catkin_tools](https://catkin-tools.readthedocs.io/en/latest/installing.html#installing-catkin-tools)
 1. Create a workspace with e.g. `mkdir -p ~/catkin_ws_teleop/src && cd ~/catkin_ws_teleop/src`
 1. Clone this repository into the workspace's `src` folder with `git clone https://github.com/hofbi/telecarla.git`
 1. Run the install script: `./install.sh`

--- a/gstreaming/source/rtsp/client/src/rtsp_client.cpp
+++ b/gstreaming/source/rtsp/client/src/rtsp_client.cpp
@@ -1,6 +1,7 @@
 #include "rtsp_client.h"
 
 #include <vector>
+
 #include <glib.h>
 #include <gst/gst.h>
 

--- a/gstreaming/source/rtsp/server/include/rtsp_server_app_source.h
+++ b/gstreaming/source/rtsp/server/include/rtsp_server_app_source.h
@@ -24,7 +24,7 @@ class RTPSServerAppSource
     const std::string& getName() const;
 
   private:
-    sensor_msgs::ImageConstPtr getScaledImagePtr(const sensor_msgs::ImageConstPtr& msg);
+    sensor_msgs::ImageConstPtr getScaledImagePtr(const sensor_msgs::ImageConstPtr& msg) const;
 
   private:
     GstClockTime timestamp_{0};

--- a/gstreaming/source/rtsp/server/src/gst_rtsp_server_util.cpp
+++ b/gstreaming/source/rtsp/server/src/gst_rtsp_server_util.cpp
@@ -81,12 +81,12 @@ GstCaps* gstCapsFromImage(const sensor_msgs::Image::ConstPtr& msg, int framerate
                                nullptr);
 }
 
-void needData(GstElement* appSrc, guint unused, RTSPServerContext* context)
+void needData(GstElement* appSrc, guint /*unused*/, RTSPServerContext* context)
 {
     context->app->bufferNewData(appSrc);
 }
 
-void mediaConfigure(GstRTSPMediaFactory* factory, GstRTSPMedia* media, RTSPServerContext* context)
+void mediaConfigure(GstRTSPMediaFactory* /*factory*/, GstRTSPMedia* media, RTSPServerContext* context)
 {
     auto element =
         std::unique_ptr<GstElement, decltype(&gst_object_unref)>(gst_rtsp_media_get_element(media), gst_object_unref);

--- a/gstreaming/source/rtsp/server/src/rtsp_server.cpp
+++ b/gstreaming/source/rtsp/server/src/rtsp_server.cpp
@@ -47,7 +47,9 @@ void RTSPServer::stop()
         state_ = RTSPState::stopping;
 
         if (handle_ != -1)
+        {
             g_source_remove(handle_);
+        }
 
         handle_ = -1;
         state_ = RTSPState::stopped;
@@ -65,7 +67,7 @@ RTSPServer::~RTSPServer()
     stop();
 }
 
-void RTSPServer::rateControlCallback(gstreaming::RateControlConfig& config, uint32_t level)
+void RTSPServer::rateControlCallback(gstreaming::RateControlConfig& config, uint32_t /*level*/)
 {
     context_->encoder->updateRateControlParameter(config.bitrate);
     context_->app->updateSpatioTemporalResolution(config.fps, config.spatial_scale);

--- a/gstreaming/source/rtsp/server/src/rtsp_server_app_source.cpp
+++ b/gstreaming/source/rtsp/server/src/rtsp_server_app_source.cpp
@@ -20,7 +20,7 @@ void RTPSServerAppSource::setVideoData(const sensor_msgs::ImageConstPtr& msg)
     mutexLock_.unlock();
 }
 
-sensor_msgs::ImageConstPtr RTPSServerAppSource::getScaledImagePtr(const sensor_msgs::ImageConstPtr& msg)
+sensor_msgs::ImageConstPtr RTPSServerAppSource::getScaledImagePtr(const sensor_msgs::ImageConstPtr& msg) const
 {
     if (spatialScale_ != 100)
     {

--- a/gstreaming/source/rtsp/server/src/rtsp_server_context.cpp
+++ b/gstreaming/source/rtsp/server/src/rtsp_server_context.cpp
@@ -2,7 +2,7 @@
 
 using namespace lmt::rtsp::server;
 
-RTSPServerContext::RTSPServerContext(const std::string& mountName, const std::string& encoderName) noexcept
+RTSPServerContext::RTSPServerContext(const std::string& mountName, const std::string& /*encoderName*/) noexcept
     : app(std::make_unique<RTPSServerAppSource>(mountName)), encoder(std::make_unique<RTSPServerEncoder>("x264encoder"))
 {
 }

--- a/gstreaming/source/src/gstreaming_client.cpp
+++ b/gstreaming/source/src/gstreaming_client.cpp
@@ -28,7 +28,7 @@ GStreamingClient::GStreamingClient(ros::NodeHandle& nh, ros::NodeHandle& pnh, in
     start(ip, port, name);
 }
 
-void GStreamingClient::callbackImage(char* data, int size, int width, int height)
+void GStreamingClient::callbackImage(char* data, int /*size*/, int width, int height)
 {
     const auto image = cv::Mat(cv::Size(width, height), CV_8UC3, data, cv::Mat::AUTO_STEP);
 

--- a/gstreaming/source/src/gstreaming_client.cpp
+++ b/gstreaming/source/src/gstreaming_client.cpp
@@ -5,7 +5,10 @@
 
 using namespace lmt;
 
-GStreamingClient::GStreamingClient(ros::NodeHandle& nh, ros::NodeHandle& pnh, int argc, char* argv[])
+GStreamingClient::GStreamingClient(ros::NodeHandle& nh,
+                                   ros::NodeHandle& pnh,
+                                   int argc,
+                                   char* argv[])  // NOLINT(modernize-avoid-c-arrays)
     : gstLifecycle_(argc, argv),
       loop_(g_main_loop_new(nullptr, false)),
       threadGstreamer_(&GStreamingClient::thrGstreamer, this),

--- a/gstreaming/source/src/gstreaming_server.cpp
+++ b/gstreaming/source/src/gstreaming_server.cpp
@@ -6,7 +6,10 @@
 using namespace lmt;
 using namespace lmt::rtsp::server;
 
-GStreamingServer::GStreamingServer(ros::NodeHandle& nh, ros::NodeHandle& pnh, int argc, char* argv[])
+GStreamingServer::GStreamingServer(ros::NodeHandle& nh,
+                                   ros::NodeHandle& pnh,
+                                   int argc,
+                                   char* argv[])  // NOLINT(modernize-avoid-c-arrays)
     : gstLifecycle_(argc, argv),
       serverPort_(pnh.param("port", 8551)),
       mountName_(pnh.param("mount", std::string("mainstream"))),

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,12 @@ pushd "$WS_SRC" || exit
 # General Packages
 sudo apt-get update
 sudo apt-get install -y \
-    software-properties-common \
     apt-utils \
+    clang-tidy-10 \
     python-pip \
     python3-pip \
-    python-protobuf
+    python-protobuf \
+    software-properties-common
 
 # Carla Ros Bridge
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 81061A1A042F527D

--- a/telecarla_gui/source/gui/src/sdl_event_parser.cpp
+++ b/telecarla_gui/source/gui/src/sdl_event_parser.cpp
@@ -1,6 +1,7 @@
 #include "sdl_event_parser.h"
 
 #include <cmath>
+
 #include <SDL2/SDL.h>
 #include <ros/ros.h>
 


### PR DESCRIPTION
There are checks I have still disabled and would like to discuss, see initial `.clang-tidy` file.

To be able to call clang-tidy, I first create a compilation database with

```shell
catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

then, still located in `catkin_ws`, I call

```shell
find src/telecarla/ -iname '*.cpp' | xargs clang-tidy -p build
```

Can we do this from the makefile? I guess we would need to go up two folders and back again. Additionally, it would be nice to check if the project has been built or at least configured (check if file `build/compile_commands.json` exists).

Do we want to run clang-tidy on test files? Currently, tests seem to pass clang-tidy, except for one weird ros include on my machine.

Finally: in `gstreaming_client.cpp` and `gstreaming_server.cpp`, our hand is forced to using char array, right? In that case, I suggest not linting that instance.