### PR TITLE
Enable and fix modernize-avoid-bind: replace std::bind with lambda

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# TODO enable modernize-avoid-bind, readability-implicit-bool-conversion, and readability-magic-numbers
+# TODO enable readability-implicit-bool-conversion and readability-magic-numbers
 
 FormatStyle: file
 
@@ -11,7 +11,6 @@ llvm*,
 misc*,
 modernize*,
 readability*,
--modernize-avoid-bind,
 -modernize-use-trailing-return-type,
 -readability-implicit-bool-conversion,
 -readability-magic-numbers,

--- a/gstreaming/source/src/gstreaming_client.cpp
+++ b/gstreaming/source/src/gstreaming_client.cpp
@@ -12,12 +12,7 @@ GStreamingClient::GStreamingClient(ros::NodeHandle& nh,
     : gstLifecycle_(argc, argv),
       loop_(g_main_loop_new(nullptr, false)),
       threadGstreamer_(&GStreamingClient::thrGstreamer, this),
-      rtspClient_(std::make_unique<rtsp::client::RTSPClient>(std::bind(&GStreamingClient::callbackImage,
-                                                                       this,
-                                                                       std::placeholders::_1,
-                                                                       std::placeholders::_2,
-                                                                       std::placeholders::_3,
-                                                                       std::placeholders::_4)))
+      rtspClient_(std::make_unique<rtsp::client::RTSPClient>([this](auto... args) { callbackImage(args...); }))
 {
     image_transport::ImageTransport it(nh);
     const auto outTopic = pnh.param("out_topic", std::string("/camera/rgb/image_color"));

--- a/gstreaming/source/src/gstreaming_server.cpp
+++ b/gstreaming/source/src/gstreaming_server.cpp
@@ -28,8 +28,7 @@ GStreamingServer::GStreamingServer(ros::NodeHandle& nh,
     subCamera_ = nh.subscribe(inTopic, 1, &RTSPServer::cameraImageCallback, rtspServer_.get());
     ROS_INFO_STREAM("Subscribed to image topic " << inTopic);
 
-    rateControl_.setCallback(
-        std::bind(&RTSPServer::rateControlCallback, rtspServer_.get(), std::placeholders::_1, std::placeholders::_2));
+    rateControl_.setCallback([this](auto... args) { rtspServer_->rateControlCallback(args...); });
 
     startStreaming();
 }


### PR DESCRIPTION
Interestingly, `clang-tidy`'s autofix suggests code that breaks compilation. I've created an mwe, see https://github.com/cbachhuber/cpp-experiments/blob/master/std_bind_vs_lambda.cpp.

Enabling the only option [PermissiveParameterList](https://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-bind.html#cmdoption-arg-permissiveparameterlist) for `modernize-avoid-bind` still produces a compilation error. Am I using `modernize-avoid-bind` wrong or have I found an issue in `clang-tidy`?