### PR TITLE
Perfect forwarding for lambdas

### DIFF
--- a/gstreaming/source/src/gstreaming_client.cpp
+++ b/gstreaming/source/src/gstreaming_client.cpp
@@ -14,8 +14,8 @@ GStreamingClient::GStreamingClient(ros::NodeHandle& nh,
     : gstLifecycle_(argc, argv),
       loop_(g_main_loop_new(nullptr, false)),
       threadGstreamer_(&GStreamingClient::thrGstreamer, this),
-      rtspClient_(
-          std::make_unique<rtsp::client::RTSPClient>([this](auto&&... args) { callbackImage(std::forward(args...)); }))
+      rtspClient_(std::make_unique<rtsp::client::RTSPClient>(
+          [this](auto&&... args) { callbackImage(std::forward<decltype(args)>(args)...); }))
 {
     image_transport::ImageTransport it(nh);
     const auto outTopic = pnh.param("out_topic", std::string("/camera/rgb/image_color"));

--- a/gstreaming/source/src/gstreaming_client.cpp
+++ b/gstreaming/source/src/gstreaming_client.cpp
@@ -1,5 +1,7 @@
 #include "gstreaming_client.h"
 
+#include <utility>
+
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
 
@@ -12,7 +14,8 @@ GStreamingClient::GStreamingClient(ros::NodeHandle& nh,
     : gstLifecycle_(argc, argv),
       loop_(g_main_loop_new(nullptr, false)),
       threadGstreamer_(&GStreamingClient::thrGstreamer, this),
-      rtspClient_(std::make_unique<rtsp::client::RTSPClient>([this](auto... args) { callbackImage(args...); }))
+      rtspClient_(
+          std::make_unique<rtsp::client::RTSPClient>([this](auto&&... args) { callbackImage(std::forward(args...)); }))
 {
     image_transport::ImageTransport it(nh);
     const auto outTopic = pnh.param("out_topic", std::string("/camera/rgb/image_color"));

--- a/gstreaming/source/src/gstreaming_server.cpp
+++ b/gstreaming/source/src/gstreaming_server.cpp
@@ -30,7 +30,8 @@ GStreamingServer::GStreamingServer(ros::NodeHandle& nh,
     subCamera_ = nh.subscribe(inTopic, 1, &RTSPServer::cameraImageCallback, rtspServer_.get());
     ROS_INFO_STREAM("Subscribed to image topic " << inTopic);
 
-    rateControl_.setCallback([this](auto&&... args) { rtspServer_->rateControlCallback(std::forward(args...)); });
+    rateControl_.setCallback(
+        [this](auto&&... args) { rtspServer_->rateControlCallback(std::forward<decltype(args)>(args)...); });
 
     startStreaming();
 }

--- a/gstreaming/source/src/gstreaming_server.cpp
+++ b/gstreaming/source/src/gstreaming_server.cpp
@@ -1,5 +1,7 @@
 #include "gstreaming_server.h"
 
+#include <utility>
+
 #include <cv_bridge/cv_bridge.h>
 #include <ros/ros.h>
 
@@ -28,7 +30,7 @@ GStreamingServer::GStreamingServer(ros::NodeHandle& nh,
     subCamera_ = nh.subscribe(inTopic, 1, &RTSPServer::cameraImageCallback, rtspServer_.get());
     ROS_INFO_STREAM("Subscribed to image topic " << inTopic);
 
-    rateControl_.setCallback([this](auto... args) { rtspServer_->rateControlCallback(args...); });
+    rateControl_.setCallback([this](auto&&... args) { rtspServer_->rateControlCallback(std::forward(args...)); });
 
     startStreaming();
 }


### PR DESCRIPTION
#7 introduced copies for the parameters of the lambda calls. I think that instead of copying, we should work on references or pass potential rvalues into the called function.