### PR TITLE
Installation instructions for formatting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,17 @@ See the main module for running the application: [telecarla](telecarla/README.md
 
 ## Code format
 
+To install formatting tools, call
+
 ```shell
-# Fomrat the code
+python3 -m pip install -r requirements.txt
+sudo snap install shfmt
+```
+
+from the source of this directory. Then, you can call
+
+```shell
+# Format the code
 make format
 
 # Check format


### PR DESCRIPTION
Add installation instructions to README, not `install.sh`. I did that to keep `install.sh` constrained to setup/build related steps as agreed in #2.