### PR TITLE
Don't use clang-tidy's readability-implicit-bool-conversion check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# TODO enable readability-implicit-bool-conversion and readability-magic-numbers
+# TODO enable readability-implicit-bool-conversion
 
 FormatStyle: file
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,3 @@
-# TODO enable readability-implicit-bool-conversion
-
 FormatStyle: file
 
 Checks: '

--- a/gstreaming/source/rtsp/client/src/rtsp_client.cpp
+++ b/gstreaming/source/rtsp/client/src/rtsp_client.cpp
@@ -13,7 +13,7 @@ GstFlowReturn RTSPClient::onNewSampleFromSink(GstAppSink* appSink, RTSPClient* d
     GstSample* sample = gst_app_sink_pull_sample(appSink);
     GstCaps* caps = gst_sample_get_caps(sample);
 
-    if (!caps)
+    if (caps == nullptr)
     {
         GST_ERROR("Could not get image info from filter caps");
         return GST_FLOW_ERROR;


### PR DESCRIPTION
I just enabled and auto-fixed `readability-implicit-bool-conversion`, but that leads to stupid solutions, see diff. It seems like clang-tidy doesn't understand ROS messages properly. A few fixes are good, but many lines would require an ugly `NOLINT` at their end.

Consequently, I lean towards cherry-picking the useful autofixes and leaving `readability-implicit-bool-conversion` disabled. Do you agree, @hofbi?