### PR TITLE
Clang tidy: check capitalization

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,4 +34,3 @@ CheckOptions:
     value:           camelBack
   - key:             readability-identifier-naming.ParameterCase
     value:           camelBack
-    

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,3 +14,24 @@ readability*,
 '
 
 WarningsAsErrors: '*'
+
+CheckOptions:
+  - key:             readability-identifier-naming.NamespaceCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StructCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MethodCase
+    value:           camelBack
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
+    

--- a/gstreaming/source/rtsp/server/src/gst_rtsp_server_util.cpp
+++ b/gstreaming/source/rtsp/server/src/gst_rtsp_server_util.cpp
@@ -45,7 +45,7 @@ sensor_msgs::ImageConstPtr getDefaultImage(int width, int height, int frameCount
 GstCaps* gstCapsFromImage(const sensor_msgs::Image::ConstPtr& msg, int framerate)
 {
     // http://gstreamer.freedesktop.org/data/doc/gstreamer/head/pwg/html/section-types-definitions.html
-    static const ros::M_string known_formats = {{
+    static const ros::M_string knownFormats = {{
         {sensor_msgs::image_encodings::RGB8, "RGB"},
         {sensor_msgs::image_encodings::RGB16, "RGB16"},
         {sensor_msgs::image_encodings::RGBA8, "RGBA"},
@@ -64,8 +64,8 @@ GstCaps* gstCapsFromImage(const sensor_msgs::Image::ConstPtr& msg, int framerate
         return nullptr;
     }
 
-    auto format = known_formats.find(msg->encoding);
-    if (format == known_formats.end())
+    auto format = knownFormats.find(msg->encoding);
+    if (format == knownFormats.end())
     {
         ROS_ERROR("GST: image format '%s' unknown", msg->encoding.c_str());
         return nullptr;

--- a/telecarla_gui/source/src/telecarla_gui.cpp
+++ b/telecarla_gui/source/src/telecarla_gui.cpp
@@ -39,8 +39,8 @@ TeleCarlaGui::TeleCarlaGui(ros::NodeHandle& nh, ros::NodeHandle& pnh)
             1,
             ImageCallback(
                 topicParam.second,
-                [ObjectPtr = &sdlGui_](const SDL_Rect& pos, const sensor_msgs::ImageConstPtr& msg, int imageFrequency) {
-                    ObjectPtr->renderImage(pos, msg, imageFrequency);
+                [objectPtr = &sdlGui_](const SDL_Rect& pos, const sensor_msgs::ImageConstPtr& msg, int imageFrequency) {
+                    objectPtr->renderImage(pos, msg, imageFrequency);
                 })));
         ROS_INFO_STREAM("Subscribed to image topic for camera " << topicParam.first << ": " << inTopic);
     }
@@ -58,8 +58,8 @@ TeleCarlaGui::TeleCarlaGui(ros::NodeHandle& nh, ros::NodeHandle& pnh)
             inTopic,
             1,
             StatusCallback(*guiParameter.getVehicleStatusParameters(),
-                           [ObjectPtr = &sdlGui_](const SDL_Rect& pos, const SDL_GUI::TextLines& textLines) {
-                               ObjectPtr->renderStaticText(pos, textLines);
+                           [objectPtr = &sdlGui_](const SDL_Rect& pos, const SDL_GUI::TextLines& textLines) {
+                               objectPtr->renderStaticText(pos, textLines);
                            })));
         ROS_INFO_STREAM("Subscribed to vehicle status topic: " << inTopic);
     }


### PR DESCRIPTION
Enable a couple of checks for `readability-identifier-naming` that cover a majority of the code. [Much more](https://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html) can be done about this topic, but I think this is a good start.

Respect, your capitalization of the checked identifiers was almost perfectly consistent already 👍 